### PR TITLE
feat: context_window_compression config for live mode

### DIFF
--- a/agent/llmagent/live_config_test.go
+++ b/agent/llmagent/live_config_test.go
@@ -40,6 +40,28 @@ func TestLiveConfigFromRunConfig(t *testing.T) {
 		}
 	})
 
+	t.Run("context_window_compression_mapped", func(t *testing.T) {
+		trigger := int64(16000)
+		target := int64(8000)
+		rc := &agent.RunConfig{
+			ContextWindowCompression: &genai.ContextWindowCompressionConfig{
+				TriggerTokens: &trigger,
+				SlidingWindow: &genai.SlidingWindow{TargetTokens: &target},
+			},
+		}
+
+		got := liveConfigFromRunConfig(rc)
+		want := &genai.LiveConnectConfig{
+			ContextWindowCompression: &genai.ContextWindowCompressionConfig{
+				TriggerTokens: &trigger,
+				SlidingWindow: &genai.SlidingWindow{TargetTokens: &target},
+			},
+		}
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("mismatch (-want +got):\n%s", diff)
+		}
+	})
+
 	t.Run("all_generation_params_mapped", func(t *testing.T) {
 		temp := float32(0.7)
 		topP := float32(0.9)

--- a/agent/llmagent/llmagent.go
+++ b/agent/llmagent/llmagent.go
@@ -494,6 +494,9 @@ func liveConfigFromRunConfig(rc *agent.RunConfig) *genai.LiveConnectConfig {
 	if rc.OutputAudioTranscription {
 		cfg.OutputAudioTranscription = &genai.AudioTranscriptionConfig{}
 	}
+	if rc.ContextWindowCompression != nil {
+		cfg.ContextWindowCompression = rc.ContextWindowCompression
+	}
 	if rc.ThinkingConfig != nil {
 		cfg.ThinkingConfig = rc.ThinkingConfig
 	}

--- a/agent/run_config.go
+++ b/agent/run_config.go
@@ -48,6 +48,9 @@ type RunConfig struct {
 	OutputAudioTranscription bool
 	ToolCoalesceWindow       time.Duration // default 150ms if zero
 	LiveBufferSize           int           // default 100 if zero
+	// ContextWindowCompression configures automatic context window compression
+	// for long-running live sessions.
+	ContextWindowCompression *genai.ContextWindowCompressionConfig
 	// Generation parameters — applied to the live session config when set.
 	ThinkingConfig  *genai.ThinkingConfig
 	Temperature     *float32


### PR DESCRIPTION
## Summary
- Added `ContextWindowCompression` field to `RunConfig` to allow configuring context window compression for live (streaming) sessions
- Mapped `ContextWindowCompression` from `RunConfig` into `LiveConnectConfig` so it is passed through to the Gemini Live API

Resolves #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)