### PR TITLE
feat: enable_affective_dialog config for live mode

### DIFF
--- a/agent/llmagent/live_config_test.go
+++ b/agent/llmagent/live_config_test.go
@@ -40,6 +40,21 @@ func TestLiveConfigFromRunConfig(t *testing.T) {
 		}
 	})
 
+	t.Run("enable_affective_dialog_mapped", func(t *testing.T) {
+		enabled := true
+		rc := &agent.RunConfig{
+			EnableAffectiveDialog: &enabled,
+		}
+
+		got := liveConfigFromRunConfig(rc)
+		want := &genai.LiveConnectConfig{
+			EnableAffectiveDialog: &enabled,
+		}
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("mismatch (-want +got):\n%s", diff)
+		}
+	})
+
 	t.Run("all_generation_params_mapped", func(t *testing.T) {
 		temp := float32(0.7)
 		topP := float32(0.9)

--- a/agent/llmagent/llmagent.go
+++ b/agent/llmagent/llmagent.go
@@ -494,6 +494,9 @@ func liveConfigFromRunConfig(rc *agent.RunConfig) *genai.LiveConnectConfig {
 	if rc.OutputAudioTranscription {
 		cfg.OutputAudioTranscription = &genai.AudioTranscriptionConfig{}
 	}
+	if rc.EnableAffectiveDialog != nil {
+		cfg.EnableAffectiveDialog = rc.EnableAffectiveDialog
+	}
 	if rc.ThinkingConfig != nil {
 		cfg.ThinkingConfig = rc.ThinkingConfig
 	}

--- a/agent/run_config.go
+++ b/agent/run_config.go
@@ -48,6 +48,9 @@ type RunConfig struct {
 	OutputAudioTranscription bool
 	ToolCoalesceWindow       time.Duration // default 150ms if zero
 	LiveBufferSize           int           // default 100 if zero
+	// EnableAffectiveDialog enables emotion detection and adaptive responses
+	// in live sessions.
+	EnableAffectiveDialog *bool
 	// Generation parameters — applied to the live session config when set.
 	ThinkingConfig  *genai.ThinkingConfig
 	Temperature     *float32


### PR DESCRIPTION
Resolves #12. Added EnableAffectiveDialog config to RunConfig and mapped to LiveConnectConfig.

🤖 Generated with [Claude Code](https://claude.com/claude-code)